### PR TITLE
Fix RockClimb insensitivity to capacitor size

### DIFF
--- a/passes/src/rockclimb/RockClimbOptimizer.cpp
+++ b/passes/src/rockclimb/RockClimbOptimizer.cpp
@@ -22,6 +22,8 @@ static bool isCallSite(const llvm::Instruction &I) {
     }
 
     llvm::Function *callee = CB->getCalledFunction();
+    // __loop_tripcount is a metadata annotation, not a real call site
+    if (callee && callee->getName() == "__loop_tripcount") return false;
     return !callee || !callee->isIntrinsic();
 }
 

--- a/passes/src/rockclimb/RockClimbPass.cpp
+++ b/passes/src/rockclimb/RockClimbPass.cpp
@@ -4,6 +4,7 @@
 #include "rockclimb/RockClimbInstrumenter.h"
 #include "rockclimb/RockClimbOptimizer.h"
 #include "common/BlockUtils.h"
+#include "common/LoopTripCount.h"
 
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/Analysis/ScalarEvolution.h"
@@ -246,7 +247,17 @@ static bool tryUnrollLoops(Function &F, LoopInfo &LI, ScalarEvolution &SE,
             }
 
             // Only unroll loops with known trip count.
-            unsigned tripCount = SE.getSmallConstantTripCount(L);
+            // Prefer __loop_tripcount markers (consistent with MILP pass),
+            // fall back to ScalarEvolution; take the conservative min if both exist.
+            auto markerTC = getMarkerTripCount(L);
+            unsigned seTripCount = SE.getSmallConstantTripCount(L);
+            unsigned tripCount;
+            if (markerTC && seTripCount)
+                tripCount = std::min(static_cast<unsigned>(*markerTC), seTripCount);
+            else if (markerTC)
+                tripCount = static_cast<unsigned>(*markerTC);
+            else
+                tripCount = seTripCount;
             if (tripCount == 0) {
                 stats.skippedUnknownTrip++;
                 LLVM_DEBUG(dbgs() << "  Loop unroll: skip " << headerName


### PR DESCRIPTION
## Summary

- **Filter `__loop_tripcount` from call-site mandatory boundaries**: `__loop_tripcount` is a metadata annotation function, not a real call site. RockClimb was treating every block containing it as a mandatory region boundary, preventing E_safe increases (larger capacitors) from merging regions. This caused identical runtime prologue counts across all capacitor sizes.
- **Use `__loop_tripcount` markers for trip counts in loop unrolling**: `tryUnrollLoops()` now uses marker-based trip counts as the primary source (consistent with the MILP pass), falling back to ScalarEvolution, and taking the conservative minimum when both are available.

## Test plan

- [x] Build passes (`cmake .. && make`)
- [x] RockClimb test suite (`./tests/run_tests.sh --rockclimb`)
- [x] Full scenario suite (`./scenario/run_scenario.sh`)
- [x] Re-run benchmarks (`./scripts/benchmark_rockclimb.sh`) to confirm runtime region counts now decrease with larger capacitors