### PR TITLE
Add configurable time limit for MILP solver

### DIFF
--- a/passes/include/milp/CheckpointOptimizer.h
+++ b/passes/include/milp/CheckpointOptimizer.h
@@ -60,6 +60,7 @@ public:
     bool solve();
 
     void setAcceptFeasible(bool accept) { acceptFeasible_ = accept; }
+    void setTimeLimit(double seconds) { timeLimit_ = seconds; }
 
     const MILPSolution &getSolution() const { return solution_; }
 
@@ -84,6 +85,7 @@ private:
     MILPSolution solution_;
     bool solved_ = false;
     bool acceptFeasible_ = false;
+    double timeLimit_ = 600.0;
 
     using BlockGVKey = std::pair<NodeId, llvm::GlobalVariable *>;
     using BlockVarKey = std::pair<NodeId, llvm::Value *>;

--- a/passes/src/common/PassRegistry.cpp
+++ b/passes/src/common/PassRegistry.cpp
@@ -30,6 +30,12 @@ cl::opt<bool> AcceptFeasibleOpt(
     cl::desc("Accept feasible (non-optimal) MILP solutions (e.g., from time limit)"),
     cl::init(false));
 
+cl::opt<double> MILPTimeLimitOpt(
+    "milp-time-limit",
+    cl::desc("Time limit for MILP solver in seconds (default: 600)"),
+    cl::value_desc("seconds"),
+    cl::init(600.0));
+
 cl::opt<bool> LoopChunkingEnabledOpt(
     "loop-chunking-enabled",
     cl::desc("Enable loop chunking before MILP passes"),

--- a/passes/src/milp/CheckpointOptimizer.cpp
+++ b/passes/src/milp/CheckpointOptimizer.cpp
@@ -108,6 +108,8 @@ bool CheckpointOptimizer::solve() {
     }
 
     buildModel();
+    if (timeLimit_ > 0.0)
+        model_.set(GRB_DoubleParam_TimeLimit, timeLimit_);
     model_.optimize();
     solved_ = true;
 

--- a/passes/src/milp/MILPCheckpointPass.cpp
+++ b/passes/src/milp/MILPCheckpointPass.cpp
@@ -24,6 +24,7 @@ using namespace llvm;
 extern cl::opt<std::string> EnergyConfigOpt;
 extern cl::opt<std::string> MILPConfigOpt;
 extern cl::opt<bool> AcceptFeasibleOpt;
+extern cl::opt<double> MILPTimeLimitOpt;
 extern cl::opt<bool> AddDebugMarkersOpt;
 
 namespace checkpoint {
@@ -92,6 +93,7 @@ PreservedAnalyses MILPCheckpointPass::run(Function &F,
     MILPInput milpInput{*abstractCFG.model, *abstractCFG.model, *abstractCFG.model};
     CheckpointOptimizer optimizer(milpInput);
     optimizer.setAcceptFeasible(AcceptFeasibleOpt);
+    optimizer.setTimeLimit(MILPTimeLimitOpt);
 
     auto infeasible = optimizer.getInfeasibleBlocks();
     if (!infeasible.empty()) {


### PR DESCRIPTION
## Summary
- Adds `-milp-time-limit=<seconds>` CLI option to set a Gurobi solver time limit (default: 600s / 10 minutes)
- Sets `GRB_DoubleParam_TimeLimit` on the Gurobi model before `optimize()`
- When the solver hits the time limit, feasible solutions are accepted if `-milp-accept-feasible` is also set

## Test plan
- [ ] Build passes and verify compilation succeeds
- [ ] Run existing test suite (`./tests/run_tests.sh`) to confirm no regressions
- [ ] Test with a short time limit (e.g., `-milp-time-limit=1`) on a complex benchmark to verify the solver respects the limit
- [ ] Verify that without `-milp-accept-feasible`, a timed-out solve correctly reports failure
- [ ] Verify that with both flags, a timed-out solve with a feasible solution is accepted