### PR TITLE
Convert __loop_tripcount() markers to !llvm.loop metadata

### DIFF
--- a/passes/CMakeLists.txt
+++ b/passes/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(CheckpointPass MODULE
     src/common/EnergyValidatorPass.cpp
     src/common/LoopTripCount.cpp
     src/common/PassRegistry.cpp
+    src/common/TripCountAnnotationPass.cpp
     # Energy estimators
     src/estimator/AssemblyBasedEstimator.cpp
     src/estimator/IRBasedEstimator.cpp

--- a/passes/include/common/LoopTripCount.h
+++ b/passes/include/common/LoopTripCount.h
@@ -1,29 +1,21 @@
 #pragma once
 
 #include "llvm/Analysis/LoopInfo.h"
-#include "llvm/IR/Function.h"
 
-#include <map>
 #include <optional>
 
 namespace checkpoint {
 
-/// Extracts loop trip count bounds from __loop_tripcount() marker calls.
-class LoopTripCount {
-public:
-    /// Extract trip counts from __loop_tripcount() calls in a function.
-    /// Scans for calls to __loop_tripcount(N) and uses LoopInfo to determine
-    /// which loop contains each call.
-    ///
-    /// @param F The function to analyze.
-    /// @param LI Loop information for the function.
-    /// @return Map from Loop* to the annotated trip count.
-    static std::map<const llvm::Loop*, unsigned>
-    extractBounds(llvm::Function &F, llvm::LoopInfo &LI);
-};
-
-/// Return the __loop_tripcount(N) marker value from a loop's header block,
-/// or std::nullopt if no marker is present.
+/// Return the trip count from !llvm.loop metadata (llvm.loop.tripcount.upper),
+/// or std::nullopt if no such metadata is present.
 std::optional<uint64_t> getMarkerTripCount(const llvm::Loop *L);
+
+/// Attach (or replace) a llvm.loop.tripcount.upper entry in the loop's
+/// !llvm.loop metadata.  Preserves any other existing metadata entries.
+void setLoopTripCountMetadata(llvm::Loop *L, uint64_t tripCount);
+
+/// Remove the llvm.loop.tripcount.upper entry from the loop's !llvm.loop
+/// metadata.  If that was the only entry, the loop ID is cleared entirely.
+void removeLoopTripCountMetadata(llvm::Loop *L);
 
 } // namespace checkpoint

--- a/passes/include/common/TripCountAnnotationPass.h
+++ b/passes/include/common/TripCountAnnotationPass.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "llvm/IR/PassManager.h"
+
+namespace checkpoint {
+
+/// Converts __loop_tripcount() function calls into !llvm.loop metadata,
+/// then erases the calls.  Must run before any optimization passes that
+/// could move or eliminate the marker calls.
+class TripCountAnnotationPass
+    : public llvm::PassInfoMixin<TripCountAnnotationPass> {
+public:
+    llvm::PreservedAnalyses run(llvm::Function &F,
+                                llvm::FunctionAnalysisManager &AM);
+
+    static llvm::StringRef name() { return "TripCountAnnotationPass"; }
+};
+
+} // namespace checkpoint

--- a/passes/src/common/LoopTripCount.cpp
+++ b/passes/src/common/LoopTripCount.cpp
@@ -1,74 +1,96 @@
 #include "common/LoopTripCount.h"
 
 #include "llvm/IR/Constants.h"
-#include "llvm/IR/Instructions.h"
-#include "llvm/Support/raw_ostream.h"
+#include "llvm/IR/Metadata.h"
 
 namespace checkpoint {
 
-std::map<const llvm::Loop*, unsigned>
-LoopTripCount::extractBounds(llvm::Function &F, llvm::LoopInfo &LI) {
-    std::map<const llvm::Loop*, unsigned> bounds;
-
-    for (llvm::BasicBlock &BB : F) {
-        for (llvm::Instruction &I : BB) {
-            auto *CI = llvm::dyn_cast<llvm::CallInst>(&I);
-            if (!CI)
-                continue;
-
-            llvm::Function *Callee = CI->getCalledFunction();
-            if (!Callee || Callee->getName() != "__loop_tripcount")
-                continue;
-
-            // Extract the constant argument
-            if (CI->arg_size() < 1)
-                continue;
-
-            auto *Arg = llvm::dyn_cast<llvm::ConstantInt>(CI->getArgOperand(0));
-            if (!Arg) {
-                llvm::errs() << "Warning: __loop_tripcount argument is not a "
-                                "constant in block "
-                             << BB.getName() << "\n";
-                continue;
-            }
-
-            unsigned tripCount = Arg->getZExtValue();
-
-            // Find the containing loop
-            llvm::Loop *L = LI.getLoopFor(&BB);
-            if (!L) {
-                llvm::errs() << "Warning: __loop_tripcount call not inside a "
-                                "loop in block "
-                             << BB.getName() << "\n";
-                continue;
-            }
-
-            // Store the bound (if multiple annotations for same loop, use max)
-            auto it = bounds.find(L);
-            if (it == bounds.end() || tripCount > it->second) {
-                bounds[L] = tripCount;
-            }
-        }
-    }
-
-    return bounds;
-}
-
 std::optional<uint64_t> getMarkerTripCount(const llvm::Loop *L) {
-    llvm::BasicBlock *Header = L->getHeader();
-    if (!Header) return std::nullopt;
-    for (const llvm::Instruction &I : *Header) {
-        if (auto *CI = llvm::dyn_cast<llvm::CallInst>(&I)) {
-            if (auto *Callee = CI->getCalledFunction()) {
-                if (Callee->getName() == "__loop_tripcount") {
-                    if (auto *C = llvm::dyn_cast<llvm::ConstantInt>(
-                            CI->getArgOperand(0)))
-                        return C->getZExtValue();
-                }
-            }
+    llvm::MDNode *LoopID = L->getLoopID();
+    if (!LoopID)
+        return std::nullopt;
+    for (unsigned i = 1; i < LoopID->getNumOperands(); i++) {
+        auto *Op = llvm::dyn_cast<llvm::MDNode>(LoopID->getOperand(i));
+        if (!Op || Op->getNumOperands() < 2)
+            continue;
+        auto *Tag = llvm::dyn_cast<llvm::MDString>(Op->getOperand(0));
+        if (Tag && Tag->getString() == "llvm.loop.tripcount.upper") {
+            auto *Val = llvm::mdconst::dyn_extract<llvm::ConstantInt>(
+                Op->getOperand(1));
+            if (Val)
+                return Val->getZExtValue();
         }
     }
     return std::nullopt;
+}
+
+void setLoopTripCountMetadata(llvm::Loop *L, uint64_t tripCount) {
+    llvm::LLVMContext &Ctx = L->getHeader()->getContext();
+    llvm::MDNode *LoopID = L->getLoopID();
+
+    llvm::SmallVector<llvm::Metadata *, 4> MDs;
+    // First operand is self-reference (placeholder, filled after creation).
+    MDs.push_back(nullptr);
+
+    // Preserve existing entries, skipping any previous tripcount.
+    if (LoopID) {
+        for (unsigned i = 1; i < LoopID->getNumOperands(); i++) {
+            auto *Op = llvm::dyn_cast<llvm::MDNode>(LoopID->getOperand(i));
+            if (Op && Op->getNumOperands() >= 1) {
+                auto *Tag = llvm::dyn_cast<llvm::MDString>(Op->getOperand(0));
+                if (Tag && Tag->getString() == "llvm.loop.tripcount.upper")
+                    continue;
+            }
+            MDs.push_back(LoopID->getOperand(i));
+        }
+    }
+
+    // Append the new tripcount entry.
+    llvm::Metadata *TCOps[] = {
+        llvm::MDString::get(Ctx, "llvm.loop.tripcount.upper"),
+        llvm::ConstantAsMetadata::get(
+            llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), tripCount))};
+    MDs.push_back(llvm::MDNode::get(Ctx, TCOps));
+
+    llvm::MDNode *NewLoopID = llvm::MDNode::getDistinct(Ctx, MDs);
+    NewLoopID->replaceOperandWith(0, NewLoopID);
+    L->setLoopID(NewLoopID);
+}
+
+void removeLoopTripCountMetadata(llvm::Loop *L) {
+    llvm::MDNode *LoopID = L->getLoopID();
+    if (!LoopID)
+        return;
+
+    llvm::LLVMContext &Ctx = L->getHeader()->getContext();
+    llvm::SmallVector<llvm::Metadata *, 4> MDs;
+    MDs.push_back(nullptr); // self-ref placeholder
+
+    bool found = false;
+    for (unsigned i = 1; i < LoopID->getNumOperands(); i++) {
+        auto *Op = llvm::dyn_cast<llvm::MDNode>(LoopID->getOperand(i));
+        if (Op && Op->getNumOperands() >= 1) {
+            auto *Tag = llvm::dyn_cast<llvm::MDString>(Op->getOperand(0));
+            if (Tag && Tag->getString() == "llvm.loop.tripcount.upper") {
+                found = true;
+                continue;
+            }
+        }
+        MDs.push_back(LoopID->getOperand(i));
+    }
+
+    if (!found)
+        return;
+
+    if (MDs.size() == 1) {
+        // Only self-reference left — remove the loop ID entirely.
+        L->setLoopID(nullptr);
+        return;
+    }
+
+    llvm::MDNode *NewLoopID = llvm::MDNode::getDistinct(Ctx, MDs);
+    NewLoopID->replaceOperandWith(0, NewLoopID);
+    L->setLoopID(NewLoopID);
 }
 
 } // namespace checkpoint

--- a/passes/src/common/PassRegistry.cpp
+++ b/passes/src/common/PassRegistry.cpp
@@ -1,4 +1,5 @@
 #include "common/EnergyValidatorPass.h"
+#include "common/TripCountAnnotationPass.h"
 #include "milp/MILPCheckpointPass.h"
 #include "milp/LoopChunkingPass.h"
 #include "rockclimb/RockClimbPass.h"
@@ -58,6 +59,7 @@ llvmGetPassPluginInfo() {
                 [](StringRef Name, FunctionPassManager &FPM,
                    ArrayRef<PassBuilder::PipelineElement>) {
                     if (Name == "checkpoint") {
+                        FPM.addPass(checkpoint::TripCountAnnotationPass());
                         FPM.addPass(LoopSimplifyPass());
                         FPM.addPass(LCSSAPass());
                         FPM.addPass(checkpoint::LoopChunkingPass());
@@ -65,6 +67,7 @@ llvmGetPassPluginInfo() {
                         return true;
                     }
                     if (Name == "milp") {
+                        FPM.addPass(checkpoint::TripCountAnnotationPass());
                         FPM.addPass(LoopSimplifyPass());
                         FPM.addPass(LCSSAPass());
                         FPM.addPass(checkpoint::LoopChunkingPass());

--- a/passes/src/common/TripCountAnnotationPass.cpp
+++ b/passes/src/common/TripCountAnnotationPass.cpp
@@ -1,0 +1,120 @@
+#include "common/TripCountAnnotationPass.h"
+#include "common/LoopTripCount.h"
+
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <map>
+
+namespace checkpoint {
+
+llvm::PreservedAnalyses
+TripCountAnnotationPass::run(llvm::Function &F,
+                             llvm::FunctionAnalysisManager &AM) {
+    if (F.isDeclaration())
+        return llvm::PreservedAnalyses::all();
+
+    auto &LI = AM.getResult<llvm::LoopAnalysis>(F);
+
+    // Step 1: Collect all __loop_tripcount calls and map them to loops.
+    std::map<llvm::Loop *, uint64_t> loopTripCounts;
+    llvm::SmallVector<llvm::CallInst *, 8> toErase;
+
+    for (llvm::BasicBlock &BB : F) {
+        for (llvm::Instruction &I : BB) {
+            auto *CI = llvm::dyn_cast<llvm::CallInst>(&I);
+            if (!CI)
+                continue;
+
+            llvm::Function *Callee = CI->getCalledFunction();
+            if (!Callee || Callee->getName() != "__loop_tripcount")
+                continue;
+
+            toErase.push_back(CI);
+
+            if (CI->arg_size() < 1)
+                continue;
+
+            auto *Arg =
+                llvm::dyn_cast<llvm::ConstantInt>(CI->getArgOperand(0));
+            if (!Arg) {
+                llvm::errs()
+                    << "Warning: __loop_tripcount argument is not a "
+                       "constant in block "
+                    << BB.getName() << "\n";
+                continue;
+            }
+
+            uint64_t tripCount = Arg->getZExtValue();
+
+            llvm::Loop *L = LI.getLoopFor(&BB);
+            if (!L) {
+                llvm::errs()
+                    << "Warning: __loop_tripcount call not inside a "
+                       "loop in block "
+                    << BB.getName() << "\n";
+                continue;
+            }
+
+            // If multiple calls map to the same loop, take the max.
+            auto it = loopTripCounts.find(L);
+            if (it == loopTripCounts.end() || tripCount > it->second)
+                loopTripCounts[L] = tripCount;
+        }
+    }
+
+    if (toErase.empty())
+        return llvm::PreservedAnalyses::all();
+
+    // Step 2: Set !llvm.loop metadata on each loop.
+    for (auto &[L, tc] : loopTripCounts) {
+        setLoopTripCountMetadata(L, tc);
+    }
+
+    // Step 3: Erase all __loop_tripcount call instructions.
+    llvm::Function *MarkerFn = nullptr;
+    for (llvm::CallInst *CI : toErase) {
+        if (!MarkerFn)
+            MarkerFn = CI->getCalledFunction();
+        CI->eraseFromParent();
+    }
+
+    // Step 4: If the marker function declaration has no remaining uses,
+    // remove it from the module.
+    if (MarkerFn && MarkerFn->use_empty())
+        MarkerFn->eraseFromParent();
+
+    // Step 5: Verify that every loop in the function now has a tripcount
+    // annotation.  Missing annotations produce hard-to-diagnose skip reasons
+    // downstream, so we catch them here.
+    bool missingAnnotation = false;
+    for (llvm::Loop *L : LI) {
+        llvm::SmallVector<llvm::Loop *, 8> worklist;
+        worklist.push_back(L);
+        while (!worklist.empty()) {
+            llvm::Loop *Current = worklist.pop_back_val();
+            if (!getMarkerTripCount(Current)) {
+                llvm::errs()
+                    << "Error: loop in " << F.getName() << " at block '"
+                    << Current->getHeader()->getName()
+                    << "' is missing a __loop_tripcount annotation\n";
+                missingAnnotation = true;
+            }
+            for (llvm::Loop *Sub : *Current)
+                worklist.push_back(Sub);
+        }
+    }
+
+    if (missingAnnotation) {
+        llvm::report_fatal_error(
+            "TripCountAnnotationPass: not all loops are annotated with "
+            "__loop_tripcount(); add annotations to the source or the pass "
+            "will not be able to determine trip counts");
+    }
+
+    return llvm::PreservedAnalyses::none();
+}
+
+} // namespace checkpoint

--- a/passes/src/milp/LoopChunkingPass.cpp
+++ b/passes/src/milp/LoopChunkingPass.cpp
@@ -98,15 +98,6 @@ static bool containsInvoke(const Loop *L) {
     return false;
 }
 
-static bool isLoopTripcountCall(const Instruction &I) {
-    auto *CI = dyn_cast<CallInst>(&I);
-    if (!CI) {
-        return false;
-    }
-    const Function *Callee = CI->getCalledFunction();
-    return Callee && Callee->getName() == "__loop_tripcount";
-}
-
 static Loop *getDirectChildLoop(const Loop *Parent, const BasicBlock *BB,
                                 const LoopInfo &LI) {
     Loop *Inner = LI.getLoopFor(BB);
@@ -115,53 +106,9 @@ static Loop *getDirectChildLoop(const Loop *Parent, const BasicBlock *BB,
     return Inner;
 }
 
-static bool isDirectlyInLoop(const BasicBlock *BB, const Loop *L,
-                             const LoopInfo &LI) {
-    return LI.getLoopFor(BB) == L;
-}
-
 using checkpoint::getMarkerTripCount;
-
-static void removeLoopTripcountMarkers(Loop *L, LoopInfo &LI) {
-    SmallVector<Instruction *, 8> toErase;
-    for (BasicBlock *BB : L->blocks()) {
-        if (!isDirectlyInLoop(BB, L, LI)) continue;
-        for (Instruction &I : *BB) {
-            if (isLoopTripcountCall(I)) {
-                toErase.push_back(&I);
-            }
-        }
-    }
-    for (Instruction *I : toErase) {
-        I->eraseFromParent();
-    }
-}
-
-static void insertLoopTripcountMarker(Loop *L, uint64_t tripCount) {
-    if (tripCount == 0) {
-        return;
-    }
-
-    BasicBlock *Header = L->getHeader();
-    auto insertPt = Header->getFirstInsertionPt();
-    if (insertPt == Header->end()) {
-        return;
-    }
-
-    Module *M = Header->getModule();
-    LLVMContext &Ctx = M->getContext();
-    auto *I32Ty = Type::getInt32Ty(Ctx);
-    auto *MarkerTy = FunctionType::get(Type::getVoidTy(Ctx), {I32Ty}, false);
-    FunctionCallee Marker = M->getOrInsertFunction("__loop_tripcount", MarkerTy);
-    if (auto *F = llvm::dyn_cast<llvm::Function>(Marker.getCallee()))
-        F->setDoesNotAccessMemory();
-
-    uint64_t maxMarker = static_cast<uint64_t>(std::numeric_limits<int32_t>::max());
-    uint64_t markerVal = std::min(tripCount, maxMarker);
-
-    IRBuilder<> B(&*insertPt);
-    B.CreateCall(Marker, {ConstantInt::get(I32Ty, markerVal)});
-}
+using checkpoint::removeLoopTripCountMetadata;
+using checkpoint::setLoopTripCountMetadata;
 
 static std::optional<uint64_t> getConstantTripCount(Loop *L,
                                                     ScalarEvolution &SE,
@@ -695,12 +642,12 @@ static bool rewriteLoopWithChunkSize(const LoopRewritePlan &plan,
         if (!remainderLoop && remTrip != 0)
             mainTrip += 1;
 
-        removeLoopTripcountMarkers(plan.L, LI);
-        insertLoopTripcountMarker(plan.L, mainTrip);
+        removeLoopTripCountMetadata(plan.L);
+        setLoopTripCountMetadata(plan.L, mainTrip);
 
         if (remainderLoop) {
-            removeLoopTripcountMarkers(remainderLoop, LI);
-            insertLoopTripcountMarker(remainderLoop, remTrip);
+            removeLoopTripCountMetadata(remainderLoop);
+            setLoopTripCountMetadata(remainderLoop, remTrip);
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix `unknown-loop-trip-count` skip reasons caused by `getMarkerTripCount()` only scanning loop header blocks — at `-O0`, `while`/`for` loops place the `__loop_tripcount()` call in the body block, not the header
- Add `TripCountAnnotationPass` that runs first in the MILP pipeline, converting all `__loop_tripcount()` function calls to `llvm.loop.tripcount.upper` metadata on the owning loop via `LI.getLoopFor()`
- Rewrite `getMarkerTripCount()` to read from loop metadata instead of scanning instructions
- Add shared `setLoopTripCountMetadata`/`removeLoopTripCountMetadata` helpers used by both the annotation pass and `LoopChunkingPass`
- Remove dead code: `extractBounds`, `isLoopTripcountCall`, old call-based marker functions

## Test plan

- [x] `passes/build` compiles cleanly (0 errors, 0 warnings)
- [x] `./tests/run_tests.sh` — all MILP, RockClimb, and comparison tests pass
- [x] `./scenario/run_scenario.sh` — all scenario tests complete without errors
- [x] `./tests/test_validate.sh` + `./tests/test_validate_milp.sh` — all 5 energy validation tests pass
- [ ] Run on RSA benchmark to verify `unknown-loop-trip-count` skip reasons are eliminated