### PR TITLE
Fix RockClimb to checkpoint PHI-defined live-out values

### DIFF
--- a/passes/src/rockclimb/DistributedCheckpointing.cpp
+++ b/passes/src/rockclimb/DistributedCheckpointing.cpp
@@ -31,10 +31,6 @@ std::set<llvm::Value*> DistributedCheckpointing::computeDefs(
             // Skip void-returning instructions (no definition)
             if (I.getType()->isVoidTy()) continue;
 
-            // Skip PHI nodes - they don't represent new definitions
-            // in the same sense (they're merge points)
-            if (llvm::isa<llvm::PHINode>(&I)) continue;
-
             // Skip allocas - they're stack slots, not registers
             if (llvm::isa<llvm::AllocaInst>(&I)) continue;
 

--- a/passes/src/rockclimb/RockClimbInstrumenter.cpp
+++ b/passes/src/rockclimb/RockClimbInstrumenter.cpp
@@ -105,14 +105,22 @@ void RockClimbInstrumenter::insertRegisterCheckpoint(
 
     // Insert AFTER the instruction that defines the register
     llvm::Instruction *afterInst = ckpt.afterInst;
-    llvm::BasicBlock::iterator insertPt(afterInst);
-    ++insertPt;  // Move to after the instruction
 
     // Handle case where instruction is terminator
     if (afterInst->isTerminator()) {
         // Can't insert after terminator in same block
         // This shouldn't happen for normal definitions, but handle gracefully
         return;
+    }
+
+    llvm::BasicBlock::iterator insertPt;
+    if (llvm::isa<llvm::PHINode>(afterInst)) {
+        // PHIs must stay grouped at block start; insert after the last PHI
+        insertPt = afterInst->getParent()->getFirstNonPHIIt();
+    } else {
+        llvm::BasicBlock::iterator it(afterInst);
+        ++it;
+        insertPt = it;
     }
 
     llvm::IRBuilder<> Builder(&*insertPt);

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -99,6 +99,7 @@ ROCKCLIMB_TESTS=(
     "test_rockclimb_nested:Nested loops - multiple loop boundaries:rockclimb:estimator_ir_weighted.json:rockclimb_params.json:O0:regions"
     "test_rockclimb_diamond:Diamond CFG - branching within regions:rockclimb:estimator_ir_weighted.json:rockclimb_params.json:O0:regions"
     "test_rockclimb_liveout:Live-out registers - distributed checkpointing:rockclimb:estimator_ir_weighted.json:rockclimb_params.json:O0:regions"
+    "test_rockclimb_phi_liveout:PHI-defined live-out - runtime checkpoint check:rockclimb:estimator_ir_weighted.json:rockclimb_params.json:O0:phi_runtime"
 )
 
 # Collect tests to run
@@ -222,6 +223,18 @@ run_test() {
                 echo -e "${GREEN}  PASS${NC}"
             else
                 echo -e "${RED}  FAIL${NC}"
+            fi
+            ;;
+        phi_runtime)
+            # Runtime test: compile to IR, mem2reg, instrument, link with driver, run
+            if [[ -x "$SCRIPT_DIR/${test_name}.sh" ]]; then
+                if "$SCRIPT_DIR/${test_name}.sh"; then
+                    echo -e "${GREEN}  PASS${NC}"
+                else
+                    echo -e "${RED}  FAIL${NC}"
+                fi
+            else
+                echo -e "${RED}  SKIP: ${test_name}.sh not found or not executable${NC}"
             fi
             ;;
     esac

--- a/tests/test_rockclimb_phi_liveout.c
+++ b/tests/test_rockclimb_phi_liveout.c
@@ -1,0 +1,77 @@
+/*
+ * RockClimb Test: PHI-Defined Live-Out Values
+ *
+ * Tests that PHI-defined values are correctly checkpointed by distributed
+ * checkpointing. A PHI node at a control-flow merge defines a value that
+ * may be live-out of its region -- if excluded from Def_r, it will never
+ * appear in Def_r ∩ LiveOut_r and won't be saved to NVM.
+ *
+ * Structure (after mem2reg):
+ *   entry → if.then (expensive_a) | if.else (expensive_b) → if.end (PHI merge)
+ *   → if.then2 (checkpoint_barrier call → mandatory boundary) → return
+ *
+ * The call to checkpoint_barrier forces a region boundary (call sites are
+ * mandatory boundaries in RockClimb). The PHI value %result.0 is defined
+ * in if.end (Region 2) and used in if.then2 (Region 3), making it live-out.
+ *
+ * With cond=0: the else path is taken, PHI resolves to expensive_b(x).
+ * %call1 (from expensive_b) is in the same region as the PHI → NOT live-out
+ * independently. Only the PHI itself is live-out across the boundary — so
+ * this path specifically tests whether PHI-defined values are checkpointed.
+ *
+ * Compile: clang -S -emit-llvm -O0 -Xclang -disable-O0-optnone
+ * Then:    opt -passes=mem2reg  (promotes stack vars to SSA/PHI form)
+ */
+
+volatile int sink;
+
+int expensive_a(int x) {
+    int acc = x;
+    acc = acc + 1;  acc = acc * 2;  acc = acc + 3;
+    acc = acc + 4;  acc = acc * 2;  acc = acc + 5;
+    acc = acc + 6;  acc = acc * 2;  acc = acc + 7;
+    acc = acc + 8;  acc = acc * 2;  acc = acc + 9;
+    sink = acc;
+    return acc;
+}
+
+int expensive_b(int x) {
+    int acc = x;
+    acc = acc - 1;  acc = acc * 3;  acc = acc - 2;
+    acc = acc - 3;  acc = acc * 3;  acc = acc - 4;
+    acc = acc - 5;  acc = acc * 3;  acc = acc - 6;
+    acc = acc - 7;  acc = acc * 3;  acc = acc - 8;
+    sink = acc;
+    return acc;
+}
+
+/* Simple function whose call forces a mandatory region boundary */
+int checkpoint_barrier(int x) {
+    sink = x;
+    return x;
+}
+
+int test_rockclimb_phi_liveout(int x, int cond) {
+    int result;
+
+    /* Branch: produces a PHI at the merge point after mem2reg */
+    if (cond) {
+        result = expensive_a(x);
+    } else {
+        result = expensive_b(x);
+    }
+    /* merge: result = PHI [expensive_a, if.then], [expensive_b, if.else] */
+
+    /* Computation in the merge block (no function calls → no forced boundary) */
+    int w = result + 1;
+    w = w * 2;
+    sink = w;
+
+    /* Branch to a block with a function call → mandatory region boundary.
+     * The PHI value 'result' is used after this boundary → live-out. */
+    if (w > 0) {
+        int z = checkpoint_barrier(w);
+        return result + z;   /* uses PHI-defined 'result' in new region */
+    }
+    return result;
+}

--- a/tests/test_rockclimb_phi_liveout.sh
+++ b/tests/test_rockclimb_phi_liveout.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Test: PHI-defined live-out values must be checkpointed by RockClimb
+#
+# Compiles a test function to IR, promotes to SSA (creating PHI nodes),
+# instruments with RockClimb, links with a runtime driver, and executes.
+# The driver simulates power failure and checks whether the PHI-defined
+# value was saved to NVM.  If not, the restored result is wrong → FAIL.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+TMP_DIR="$PROJECT_DIR/tmp"
+
+# Load environment variables from .env if it exists
+if [[ -f "$PROJECT_DIR/.env" ]]; then
+    source "$PROJECT_DIR/.env"
+fi
+
+# LLVM tools (build clang for IR generation/opt, system clang for native compilation)
+if [[ -n "${LLVM_DIR}" ]]; then
+    CLANG="${CLANG:-${LLVM_DIR}/bin/clang}"
+    OPT="${OPT:-${LLVM_DIR}/bin/opt}"
+else
+    CLANG="${CLANG:-clang}"
+    OPT="${OPT:-opt}"
+fi
+# System compiler for native C compilation (needs SDK headers)
+SYS_CC="${SYS_CC:-/usr/bin/clang}"
+
+PASS_LIB="$PROJECT_DIR/passes/build/CheckpointPass.so"
+ESTIMATOR_CONFIG="$SCRIPT_DIR/estimator_ir_weighted.json"
+ROCKCLIMB_CONFIG="$SCRIPT_DIR/rockclimb_params.json"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+mkdir -p "$TMP_DIR"
+
+TEST_C="$SCRIPT_DIR/test_rockclimb_phi_liveout.c"
+DRIVER_C="$SCRIPT_DIR/test_rockclimb_phi_liveout_driver.c"
+RAW_LL="$TMP_DIR/phi_liveout_raw.ll"
+SSA_LL="$TMP_DIR/phi_liveout_ssa.ll"
+OUT_LL="$TMP_DIR/phi_liveout_out.ll"
+OUT_OBJ="$TMP_DIR/phi_liveout_out.o"
+DRIVER_OBJ="$TMP_DIR/phi_liveout_driver.o"
+EXECUTABLE="$TMP_DIR/phi_liveout_test"
+
+echo "=== Test: PHI-defined live-out checkpointing (runtime) ==="
+echo ""
+
+# Step 1: Compile test function to LLVM IR
+echo "1. Compiling test to LLVM IR..."
+"$CLANG" -S -emit-llvm -O0 -Xclang -disable-O0-optnone "$TEST_C" -o "$RAW_LL"
+
+# Step 2: Promote to SSA to get PHI nodes
+echo "2. Promoting to SSA (mem2reg)..."
+"$OPT" -passes=mem2reg -S "$RAW_LL" -o "$SSA_LL"
+
+# Step 3: Verify PHI nodes exist
+echo "3. Checking for PHI nodes..."
+if grep -q "= phi " "$SSA_LL"; then
+    echo "   OK: PHI nodes found"
+else
+    echo -e "   ${RED}FAIL: No PHI nodes -- test is invalid${NC}"
+    exit 1
+fi
+
+# Step 4: Run RockClimb pass
+echo "4. Running RockClimb pass..."
+"$OPT" -load-pass-plugin="$PASS_LIB" \
+    -passes=rockclimb \
+    -energy-config="$ESTIMATOR_CONFIG" \
+    -rockclimb-config="$ROCKCLIMB_CONFIG" \
+    -S "$SSA_LL" -o "$OUT_LL" 2>&1
+
+# Step 5: Compile instrumented IR to object
+echo "5. Compiling instrumented IR to object..."
+"$SYS_CC" -c "$OUT_LL" -o "$OUT_OBJ"
+
+# Step 6: Compile runtime driver
+echo "6. Compiling runtime driver..."
+"$SYS_CC" -c "$DRIVER_C" -o "$DRIVER_OBJ"
+
+# Step 7: Link
+echo "7. Linking..."
+"$SYS_CC" "$OUT_OBJ" "$DRIVER_OBJ" -o "$EXECUTABLE"
+
+# Step 8: Run
+echo "8. Running test executable..."
+echo ""
+if "$EXECUTABLE"; then
+    echo ""
+    echo -e "${GREEN}TEST PASSED${NC}"
+    exit 0
+else
+    echo ""
+    echo -e "${RED}TEST FAILED${NC}"
+    exit 1
+fi

--- a/tests/test_rockclimb_phi_liveout_driver.c
+++ b/tests/test_rockclimb_phi_liveout_driver.c
@@ -1,0 +1,123 @@
+/*
+ * Runtime driver for PHI-defined live-out checkpoint test.
+ *
+ * Provides runtime stubs (__rockclimb_check, __rockclimb_save_reg, __nvm_regs)
+ * and a main() that:
+ *   1. Runs the instrumented function (golden result)
+ *   2. Checks whether the PHI-defined value was saved to NVM
+ *   3. Simulates a power-failure restart using only NVM-saved values
+ *   4. Compares reconstructed result against golden
+ *
+ * If the PHI value was NOT checkpointed, the reconstructed result is WRONG
+ * -- demonstrating data loss on power failure.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+/* NVM storage -- the only state that survives power failure */
+#define NVM_SIZE 32
+int __nvm_regs[NVM_SIZE];
+
+/* Track every __rockclimb_save_reg call */
+#define MAX_SAVES 64
+static int save_ids[MAX_SAVES];
+static int save_vals[MAX_SAVES];
+static int save_count = 0;
+
+/* Runtime stubs */
+void __rockclimb_check(void) {
+    /* no-op: boundary marker only */
+}
+
+void __rockclimb_save_reg(int id, int val) {
+    if (id < NVM_SIZE)
+        __nvm_regs[id] = val;
+    if (save_count < MAX_SAVES) {
+        save_ids[save_count] = id;
+        save_vals[save_count] = val;
+        save_count++;
+    }
+}
+
+/* Functions from the instrumented test module */
+extern int test_rockclimb_phi_liveout(int x, int cond);
+extern int expensive_a(int x);
+
+int main(void) {
+    int x = 42;
+    int cond = 1;  /* then path: PHI resolves to expensive_a(x) */
+
+    /*
+     * Why cond=1?  LLVM's RPO puts if.else in its own region and if.then
+     * in the same region as if.end (the merge block).  With cond=0 the
+     * PHI input (%call1 from if.else) is independently live-out and saved,
+     * masking the bug.  With cond=1 the PHI input (%call from if.then) is
+     * in the same region as the merge block — NOT independently live-out.
+     * Only if the PHI node itself is treated as a definition will it be
+     * checkpointed.
+     */
+
+    memset(__nvm_regs, 0, sizeof(__nvm_regs));
+    save_count = 0;
+
+    /* ---- Golden run ---- */
+    int golden = test_rockclimb_phi_liveout(x, cond);
+
+    /* Independently compute the expected PHI value.
+     * expensive_a has 0 checkpoints so calling it won't affect NVM state. */
+    int expected_phi = expensive_a(x);
+
+    /* ---- Check NVM for the PHI value ---- */
+    int phi_in_nvm = 0;
+    for (int i = 0; i < save_count; i++) {
+        if (save_vals[i] == expected_phi) {
+            phi_in_nvm = 1;
+            break;
+        }
+    }
+
+    /* Find w = (result + 1) * 2 in NVM (non-PHI value, always checkpointed) */
+    int expected_w = (expected_phi + 1) * 2;
+    int w_in_nvm = 0;
+    for (int i = 0; i < save_count; i++) {
+        if (save_vals[i] == expected_w) {
+            w_in_nvm = 1;
+            break;
+        }
+    }
+
+    /* ---- Simulate power-failure restart ----
+     * Only NVM-saved values survive. Post-boundary code does:
+     *   z = checkpoint_barrier(w);  // z = w
+     *   return result + z;
+     */
+    int restored_phi = phi_in_nvm ? expected_phi : 0;
+    int restored_w   = w_in_nvm   ? expected_w   : 0;
+    int restored_result = restored_phi + restored_w;
+
+    /* ---- Report ---- */
+    printf("=== PHI Live-Out Runtime Test ===\n");
+    printf("Input: x=%d, cond=%d\n", x, cond);
+    printf("Golden result:              %d\n", golden);
+    printf("Expected PHI value:         %d\n", expected_phi);
+    printf("NVM saves (%d total):\n", save_count);
+    for (int i = 0; i < save_count; i++) {
+        const char *tag = "";
+        if (save_vals[i] == expected_phi) tag = " <-- PHI";
+        if (save_vals[i] == expected_w)   tag = " <-- w";
+        printf("  nvm_reg[%d] = %d%s\n", save_ids[i], save_vals[i], tag);
+    }
+    printf("PHI in NVM:                 %s\n", phi_in_nvm ? "yes" : "NO");
+    printf("Result after power failure: %d\n", restored_result);
+
+    if (restored_result == golden) {
+        printf("\nPASS: power failure preserves correct result\n");
+        return 0;
+    } else {
+        printf("\nFAIL: power failure gives %d instead of %d\n",
+               restored_result, golden);
+        printf("  PHI-defined value was not saved to NVM -- data loss on reboot.\n");
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

- Fix silent data loss in RockClimb's distributed checkpointing: PHI-defined values that are live-out of their region were never saved to NVM because `computeDefs()` explicitly skipped PHI nodes
- Handle PHI insertion points in `RockClimbInstrumenter` by placing checkpoint stores after the last PHI via `getFirstNonPHIIt()` to respect LLVM's PHI grouping invariant
- Add a runtime test that compiles, instruments, links, and executes, simulating power failure to verify correctness — without the fix, the result is wrong (1656 vs 2483)

## Test plan

- [x] RED: `test_rockclimb_phi_liveout.sh` fails before fix (PHI value 827 missing from NVM, reconstructed result 1656 != golden 2483)
- [x] GREEN: test passes after fix (PHI value saved to NVM, reconstructed result matches golden)
- [x] `./tests/run_tests.sh --rockclimb` — all 6 RockClimb tests pass (no regressions)
- [x] `./scenario/run_scenario.sh` — all scenario tests pass (exit 0)